### PR TITLE
[#12] time 입력 형식 - 소수점 및 정수 케이스 추가

### DIFF
--- a/src/main/kotlin/com/easternkite/remain/Routing.kt
+++ b/src/main/kotlin/com/easternkite/remain/Routing.kt
@@ -50,16 +50,26 @@ fun Application.configureRouting() {
     }
 }
 
+
+/**
+ * 입력된 시간을 "HH:mm" 형식으로 변환합니다.
+ * - 소수 입력: "20.5" → "20:30" (소수점은 1자리까지만 허용)
+ * - 정수 입력: "20" → "20:00"
+ * - 기존 형식: "20:30" → 그대로 반환
+ *
+ * @return 변환된 "HH:mm" 형식의 시간 문자열
+ * @throws IllegalArgumentException 유효하지 않은 소수점 입력인 경우
+ */
 fun String.fracFormat(): String {
     return when {
         contains('.') -> {
             val (hour, frac) = split(".").map(String::toInt)
             require(frac in 0..9) { "Invalid fraction value: $frac. Allowed range is 0-9." }
             val minute = frac * 6
-            "%02d:%02d".format(hour, minute) // "HH:mm" 형식 반환
+            "%02d:%02d".format(hour, minute)
         }
         !contains(':') -> {
-            "%02d:00".format(toInt())       //  정수 입력 케이스
+            "%02d:00".format(toInt())
         }
         else -> this
     }

--- a/src/main/kotlin/com/easternkite/remain/Routing.kt
+++ b/src/main/kotlin/com/easternkite/remain/Routing.kt
@@ -44,7 +44,15 @@ fun Application.configureRouting() {
                     contentType = ContentType.Application.Json
                 )
             }.onFailure { error ->
-                call.respond("${HttpStatusCode.BadRequest} - ${error.message}")
+                val errorResponse = DrResponse(
+                    text = "${HttpStatusCode.BadRequest} - ${error.message}",
+                    responseType = "ephemeral" // 작성자한테만 표시
+                )
+
+                call.respondText(
+                    text = Json.encodeToString(errorResponse),
+                    contentType = ContentType.Application.Json
+                )
             }
         }
     }

--- a/src/test/kotlin/com/easternkite/remain/ApplicationTest.kt
+++ b/src/test/kotlin/com/easternkite/remain/ApplicationTest.kt
@@ -57,4 +57,28 @@ class ApplicationTest {
             assertEquals(HttpStatusCode.OK, status)
         }
     }
+
+    @Test
+    fun testTimeFractionFormat() = testApplication {
+        application {
+            module()
+        }
+        val client = createClient {
+            install(ContentNegotiation) {
+                json()
+            }
+        }
+        client.post("/time") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                DrRequestBody(
+                    text = "19.5",
+                    command = "/time"
+                )
+            )
+        }.apply {
+            println("response = ${bodyAsText()}")
+            assertEquals(HttpStatusCode.OK, status)
+        }
+    }
 }


### PR DESCRIPTION
### Changes
- 기존 시간 입력 형식 `HH:mm` 외에 정수와 소수점 형식도 지원하도록 `fracFormat` 함수에 변환 로직을 구현하였습니다. 
- 입력된 시간 형식을 변환하여 `HH:mm` 형식으로 처리
  - "20" → "20:00"
  - "20.5" → "20:30"
  - "20:30" → 그대로 사용
- **소수점 입력값은 1자리까지만 허용**
  - "20.99" → 예외 발생 -  `Invalid fraction value: 99. Allowed range is 0-9.`

### Testing
- **테스트 코드 추가** - `testTimeFractionFormat()`

##
✨ Feat: First time with Kotlin (finally😋)...  <sup>because typing 19:30 is too much</sup> ⏳⏰